### PR TITLE
Proportional heating

### DIFF
--- a/user.h
+++ b/user.h
@@ -25,7 +25,7 @@
 
 // How many readings are taken to determine a mean temperature.
 // accounts for the thermocouple noise
-#define NUMREADINGS 8
+#define NUMREADINGS 16
 
 // delay between 2 control updates
 // (must be larger than LOOP_PERIOD_MS)

--- a/user.h
+++ b/user.h
@@ -31,6 +31,13 @@
 // (must be larger than LOOP_PERIOD_MS)
 #define CONTROL_UPDATE_PERIOD_MS 2000
 
+// minimal time for the SSR to be on
+#define MINIMAL_SSR_MS 100
+
+// the temperature difference from the objective when a full heating cycle is needed, in Celsius
+// when the temperature difference is lower than this value, the heating cycle length is proportional to this difference
+#define PROPORTIONAL_TEMP_RANGE 20.0
+
 // Pin mapping 
 // Common SPI pins 
 #define DOPIN 12


### PR DESCRIPTION
In each 2-seconds cycle, decide how long to switch on each heater based on how far the projected temperature is from the objective.

A full cycle is done when the temperature difference is more than 20 °C.

Heater 1 takes priority if the sum of the heating steps is longer than the cycle.

Relays won't be switched on and off at more than 10 Hz.

Also double the window for temperature averaging, since there is still a lot of noise in the temperature readings.